### PR TITLE
reinsert dependecies in allready created systems

### DIFF
--- a/Modules/EcsModule.cs
+++ b/Modules/EcsModule.cs
@@ -158,8 +158,7 @@ namespace ModulesFramework.Modules
 
                 if (!_systems.ContainsKey(order))
                     _systems[order] = new SystemsGroup();
-
-                InsertDependencies(system, world);
+                
                 _systems[order].Add(system);
             }
         }
@@ -175,6 +174,9 @@ namespace ModulesFramework.Modules
             world.Logger.LogDebug($"Module {GetType().Name} systems preinit", LogFilter.SystemsInit);
             #endif
 
+            foreach (var system in _createdSystem)
+                InsertDependencies(system, world);
+            
             foreach (var p in _systems)
                 p.Value.PreInit(world);
 


### PR DESCRIPTION
was: dependencies are inserts into systems only when they are created
now: dependencies are inserts into systems each module initialization